### PR TITLE
[REL-142] Provide end timestamp to spans and transactions

### DIFF
--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -30,8 +30,7 @@ SENTRY_NO_INIT
 /**
  * Inits and configures Sentry (SentryHub, SentryClient) and sets up all integrations.
  */
-+ (void)startWithOptions:(NSDictionary<NSString *, id> *)optionsDict
-    NS_SWIFT_NAME(start(options:));
++ (void)startWithOptions:(NSDictionary<NSString *, id> *)optionsDict NS_SWIFT_NAME(start(options:));
 
 /**
  * Inits and configures Sentry (SentryHub, SentryClient) and sets up all integrations.
@@ -76,8 +75,7 @@ SENTRY_NO_INIT
  * @return The SentryId of the event or SentryId.empty if the event is not sent.
  */
 + (SentryId *)captureEvent:(SentryEvent *)event
-            withScopeBlock:(void (^)(SentryScope *scope))block
-    NS_SWIFT_NAME(capture(event:block:));
+            withScopeBlock:(void (^)(SentryScope *scope))block NS_SWIFT_NAME(capture(event:block:));
 
 /**
  * Creates a transaction, binds it to the hub and returns the instance.
@@ -184,8 +182,7 @@ SENTRY_NO_INIT
  * @return The SentryId of the event or SentryId.empty if the event is not sent.
  */
 + (SentryId *)captureError:(NSError *)error
-            withScopeBlock:(void (^)(SentryScope *scope))block
-    NS_SWIFT_NAME(capture(error:block:));
+            withScopeBlock:(void (^)(SentryScope *scope))block NS_SWIFT_NAME(capture(error:block:));
 
 /**
  * Captures an exception event and sends it to Sentry.

--- a/Sources/Sentry/Public/SentrySpanProtocol.h
+++ b/Sources/Sentry/Public/SentrySpanProtocol.h
@@ -64,15 +64,13 @@ NS_SWIFT_NAME(Span)
 /**
  * Sets a value to data.
  */
-- (void)setDataValue:(nullable id)value
-              forKey:(NSString *)key NS_SWIFT_NAME(setData(value:key:));
+- (void)setDataValue:(nullable id)value forKey:(NSString *)key NS_SWIFT_NAME(setData(value:key:));
 
 /**
  * Use setDataValue instead. This method calls setDataValue, was added by mistake, and will be
  * deprecated in a future version.
  */
-- (void)setExtraValue:(nullable id)value
-               forKey:(NSString *)key NS_SWIFT_NAME(setExtra(value:key:));
+- (void)setExtraValue:(nullable id)value forKey:(NSString *)key NS_SWIFT_NAME(setExtra(value:key:));
 
 /**
  * Removes a data value.
@@ -97,7 +95,8 @@ NS_SWIFT_NAME(Span)
 /**
  * Finishes the span by setting the end time to the provided value.
  *
- * @param timestamp The timestamp at which the span ended, if null then value of `+[SentryCurrentDate date]` used
+ * @param timestamp The timestamp at which the span ended, if null then value of
+ * `+[SentryCurrentDate date]` used
  */
 - (void)finishWithTimestamp:(nullable NSDate *)timestamp NS_SWIFT_NAME(finish(timestamp:));
 
@@ -112,9 +111,11 @@ NS_SWIFT_NAME(Span)
  * Finishes the span by setting the end time and span status.
  *
  * @param status The status of this span
- * @param timestamp The timestamp at which the span ended, if null then value of `+[SentryCurrentDate date]` used
+ * @param timestamp The timestamp at which the span ended, if null then value of
+ * `+[SentryCurrentDate date]` used
  *  */
-- (void)finishWithStatus:(SentrySpanStatus)status timestamp:(nullable NSDate *)timestamp NS_SWIFT_NAME(finish(status:timestamp:));
+- (void)finishWithStatus:(SentrySpanStatus)status
+               timestamp:(nullable NSDate *)timestamp NS_SWIFT_NAME(finish(status:timestamp:));
 
 /**
  * Returns the trace information that could be sent as a sentry-trace header.

--- a/Sources/Sentry/Public/SentrySpanProtocol.h
+++ b/Sources/Sentry/Public/SentrySpanProtocol.h
@@ -95,11 +95,26 @@ NS_SWIFT_NAME(Span)
 - (void)finish;
 
 /**
+ * Finishes the span by setting the end time to the provided value.
+ *
+ * @param timestamp The timestamp at which the span ended, if null then value of `+[SentryCurrentDate date]` used
+ */
+- (void)finishWithTimestamp:(nullable NSDate *)timestamp NS_SWIFT_NAME(finish(timestamp:));
+
+/**
  * Finishes the span by setting the end time and span status.
  *
  * @param status The status of this span
  *  */
 - (void)finishWithStatus:(SentrySpanStatus)status NS_SWIFT_NAME(finish(status:));
+
+/**
+ * Finishes the span by setting the end time and span status.
+ *
+ * @param status The status of this span
+ * @param timestamp The timestamp at which the span ended, if null then value of `+[SentryCurrentDate date]` used
+ *  */
+- (void)finishWithStatus:(SentrySpanStatus)status timestamp:(nullable NSDate *)timestamp NS_SWIFT_NAME(finish(status:timestamp:));
 
 /**
  * Returns the trace information that could be sent as a sentry-trace header.

--- a/Sources/Sentry/SentryNoOpSpan.m
+++ b/Sources/Sentry/SentryNoOpSpan.m
@@ -78,7 +78,15 @@ NS_ASSUME_NONNULL_BEGIN
 {
 }
 
+- (void)finishWithTimestamp:(nullable NSDate *)timestamp
+{
+}
+
 - (void)finishWithStatus:(SentrySpanStatus)status
+{
+}
+
+- (void)finishWithStatus:(SentrySpanStatus)status timestamp:(nullable NSDate *)timestamp
 {
 }
 

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -112,8 +112,7 @@ SentrySpan ()
     [self finishWithStatus:status timestamp:[SentryCurrentDate date]];
 }
 
-- (void)finishWithStatus:(SentrySpanStatus)status
-               timestamp:(nullable NSDate *)timestamp
+- (void)finishWithStatus:(SentrySpanStatus)status timestamp:(nullable NSDate *)timestamp
 {
     self.context.status = status;
     self.timestamp = timestamp ?: [SentryCurrentDate date];

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -102,10 +102,21 @@ SentrySpan ()
     [self finishWithStatus:kSentrySpanStatusOk];
 }
 
+- (void)finishWithTimestamp:(nullable NSDate *)timestamp
+{
+    [self finishWithStatus:kSentrySpanStatusOk timestamp:timestamp];
+}
+
 - (void)finishWithStatus:(SentrySpanStatus)status
 {
+    [self finishWithStatus:status timestamp:[SentryCurrentDate date]];
+}
+
+- (void)finishWithStatus:(SentrySpanStatus)status
+               timestamp:(nullable NSDate *)timestamp
+{
     self.context.status = status;
-    self.timestamp = [SentryCurrentDate date];
+    self.timestamp = timestamp ?: [SentryCurrentDate date];
     if (self.transaction != nil) {
         [self.transaction spanFinished:self];
     }

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -411,10 +411,10 @@ installExceptionHandler()
 
     const task_t thisTask = mach_task_self();
     // This is the default, which breaks widevine:
-    // `exception_mask_t mask = EXC_MASK_BAD_ACCESS | EXC_MASK_BAD_INSTRUCTION | EXC_MASK_ARITHMETIC | EXC_MASK_SOFTWARE | EXC_MASK_BREAKPOINT;`
-    // Following is used by chromium's crashpad, which works with widevine
-    // We're not seeing some crashed being picked up by the mach exception handler with this
-    // but they still end up in Sentry via the signal handler.
+    // `exception_mask_t mask = EXC_MASK_BAD_ACCESS | EXC_MASK_BAD_INSTRUCTION | EXC_MASK_ARITHMETIC
+    // | EXC_MASK_SOFTWARE | EXC_MASK_BREAKPOINT;` Following is used by chromium's crashpad, which
+    // works with widevine We're not seeing some crashed being picked up by the mach exception
+    // handler with this but they still end up in Sentry via the signal handler.
     exception_mask_t mask = EXC_MASK_CRASH | EXC_MASK_BAD_ACCESS;
 
     SentryCrashLOG_DEBUG("Backing up original exception ports.");

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Zombie.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Zombie.c
@@ -84,11 +84,20 @@ copyStringIvar(const void *self, const char *ivarName, char *buffer, int bufferL
                     SentryCrashLOG_DEBUG("sentrycrashobjc_copyStringContents %s failed", ivarName);
                 }
             }
-            else { SentryCrashLOG_DEBUG("sentrycrashobjc_isValidObject %s failed", ivarName); }
+            else
+            {
+                SentryCrashLOG_DEBUG("sentrycrashobjc_isValidObject %s failed", ivarName);
+            }
         }
-        else { SentryCrashLOG_DEBUG("sentrycrashobjc_ivarValue %s failed", ivarName); }
+        else
+        {
+            SentryCrashLOG_DEBUG("sentrycrashobjc_ivarValue %s failed", ivarName);
+        }
     }
-    else { SentryCrashLOG_DEBUG("sentrycrashobjc_ivarNamed %s failed", ivarName); }
+    else
+    {
+        SentryCrashLOG_DEBUG("sentrycrashobjc_ivarNamed %s failed", ivarName);
+    }
     return false;
 }
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashString.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashString.c
@@ -164,7 +164,10 @@ sentrycrashstring_isNullTerminatedUTF8String(const void *memory, int minLength, 
                 unlikely_if((*ptr & 0xc0) != 0x80) { return false; }
             }
         }
-        else unlikely_if(ch < 0x20 && !g_printableControlChars[ch]) { return false; }
+        else unlikely_if(ch < 0x20 && !g_printableControlChars[ch])
+        {
+            return false;
+        }
     }
     return false;
 }

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -273,14 +273,17 @@ class SentrySpanTests: XCTestCase {
         let span = fixture.getSut(client: client)
 
         let startTimestamp = TestData.timestamp
+        // Set finish time to after the start time
         let finishTimestamp = TestData.timestamp.addingTimeInterval(20)
-        fixture.currentDateProvider.setDate(date: TestData.timestamp.addingTimeInterval(20))
+        // Set "current date" to even later than the finish time
+        fixture.currentDateProvider.setDate(date: TestData.timestamp.addingTimeInterval(40))
 
         span.finish(timestamp: finishTimestamp)
 
-        XCTAssertEqual(span.startTimestamp, startTimestamp)
-        XCTAssertEqual(span.timestamp, finishTimestamp)
-        XCTAssertNotEqual(span.timestamp, TestData.timestamp)
+        XCTAssertEqual(span.startTimestamp?.timeIntervalSince1970, startTimestamp.timeIntervalSince1970)
+        XCTAssertEqual(span.timestamp?.timeIntervalSince1970, finishTimestamp.timeIntervalSince1970)
+        XCTAssertNotEqual(span.startTimestamp?.timeIntervalSince1970, span.timestamp?.timeIntervalSince1970)
+        XCTAssertNotEqual(span.timestamp?.timeIntervalSince1970, fixture.currentDateProvider.date().timeIntervalSince1970)
         XCTAssertTrue(span.isFinished)
         XCTAssertEqual(span.context.status, .ok)
     }

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -267,4 +267,21 @@ class SentrySpanTests: XCTestCase {
         group.wait()
         XCTAssertEqual(span.data!.count, outerLoop * innerLoop)
     }
+
+    func testFinishTimestampIsParameterNotCurrent() {
+        let client = TestClient(options: fixture.options)!
+        let span = fixture.getSut(client: client)
+
+        let startTimestamp = TestData.timestamp
+        let finishTimestamp = TestData.timestamp.addingTimeInterval(20)
+        fixture.currentDateProvider.setDate(date: TestData.timestamp.addingTimeInterval(20))
+
+        span.finish(timestamp: finishTimestamp)
+
+        XCTAssertEqual(span.startTimestamp, startTimestamp)
+        XCTAssertEqual(span.timestamp, finishTimestamp)
+        XCTAssertNotEqual(span.timestamp, TestData.timestamp)
+        XCTAssertTrue(span.isFinished)
+        XCTAssertEqual(span.context.status, .ok)
+    }
 }

--- a/Tests/SentryTests/Transaction/TestSentrySpan.m
+++ b/Tests/SentryTests/Transaction/TestSentrySpan.m
@@ -39,6 +39,14 @@
 {
 }
 
+- (void)finishWithTimestamp:(NSDate *)timestamp
+{
+}
+
+- (void)finishWithStatus:(SentrySpanStatus)status timestamp:(NSDate *)timestamp
+{
+}
+
 - (void)removeDataForKey:(nonnull NSString *)key
 {
 }


### PR DESCRIPTION
## :scroll: Description

We would like the ability to set the exact time that a span completes, however this is not currently possible. As the 
system worked originally when the consumer would call `finish` on a span or transaction (which would then call the 
`-[rootSpan finish]`) Sentry would pluck out the "current date" and use that as the finish timestamp. Then, if the 
transaction were completed the transaction would be "captured" and sent on its way to the server. Thus, for subspans it
was possible to mutate the finish timestamp but not for the transaction which would lead to potentially strange results
if the subspan end timestamps were significantly different from the transaction's end timespan (like if the finishes 
are called on another DispatchQueue that takes a while to execute queued call to `finish`).

This can be solved by allowing callers to pass in the finish timestamp if they like. Then if this value is present the 
SDK will use that, otherwise it will fall back to the "current date" value that it has always used.

## :green_heart: How did you test it?

- Existing unit tests 
- By adding transactions to our app and incrementing their start and end timestamps by 10ms for uniform durations, checking the Sentry site and noting that all spans were multiples of 10ms in duration.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
