### PR TITLE
[REL-382] Use Sentry's implementation of finishing with custom timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Report App Memory Usage (#2027)
+- Include app permissions with event (#1984)
+- Add culture context to event (#2036)
+- Attach view hierarchy to events (#2044)
+- Clean up SentryOptions: added `enableCrashHandler` and deprecated `integrations` (#2049)
+
+### Fix
+
+- Add span finish flag (#2059)
+
 ## 7.23.0
 
 ### Features

--- a/Sources/Sentry/Public/SentrySpanProtocol.h
+++ b/Sources/Sentry/Public/SentrySpanProtocol.h
@@ -93,29 +93,11 @@ NS_SWIFT_NAME(Span)
 - (void)finish;
 
 /**
- * Finishes the span by setting the end time to the provided value.
- *
- * @param timestamp The timestamp at which the span ended, if null then value of
- * `+[SentryCurrentDate date]` used
- */
-- (void)finishWithTimestamp:(nullable NSDate *)timestamp NS_SWIFT_NAME(finish(timestamp:));
-
-/**
  * Finishes the span by setting the end time and span status.
  *
  * @param status The status of this span
  *  */
 - (void)finishWithStatus:(SentrySpanStatus)status NS_SWIFT_NAME(finish(status:));
-
-/**
- * Finishes the span by setting the end time and span status.
- *
- * @param status The status of this span
- * @param timestamp The timestamp at which the span ended, if null then value of
- * `+[SentryCurrentDate date]` used
- *  */
-- (void)finishWithStatus:(SentrySpanStatus)status
-               timestamp:(nullable NSDate *)timestamp NS_SWIFT_NAME(finish(status:timestamp:));
 
 /**
  * Returns the trace information that could be sent as a sentry-trace header.

--- a/Sources/Sentry/SentryNoOpSpan.m
+++ b/Sources/Sentry/SentryNoOpSpan.m
@@ -78,15 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
 }
 
-- (void)finishWithTimestamp:(nullable NSDate *)timestamp
-{
-}
-
 - (void)finishWithStatus:(SentrySpanStatus)status
-{
-}
-
-- (void)finishWithStatus:(SentrySpanStatus)status timestamp:(nullable NSDate *)timestamp
 {
 }
 

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -15,6 +15,7 @@ SentrySpan ()
 @implementation SentrySpan {
     NSMutableDictionary<NSString *, id> *_data;
     NSMutableDictionary<NSString *, id> *_tags;
+    BOOL _isFinished;
 }
 
 - (instancetype)initWithTransaction:(SentryTracer *)transaction context:(SentrySpanContext *)context
@@ -25,6 +26,7 @@ SentrySpan ()
         self.startTimestamp = [SentryCurrentDate date];
         _data = [[NSMutableDictionary alloc] init];
         _tags = [[NSMutableDictionary alloc] init];
+        _isFinished = NO;
     }
     return self;
 }
@@ -95,7 +97,7 @@ SentrySpan ()
 
 - (BOOL)isFinished
 {
-    return self.timestamp != nil;
+    return _isFinished;
 }
 
 - (void)finish
@@ -106,6 +108,7 @@ SentrySpan ()
 - (void)finishWithStatus:(SentrySpanStatus)status
 {
     self.context.status = status;
+    _isFinished = YES;
     if (self.timestamp == nil) {
         self.timestamp = [SentryCurrentDate date];
     }

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -103,17 +103,7 @@ SentrySpan ()
     [self finishWithStatus:kSentrySpanStatusOk];
 }
 
-- (void)finishWithTimestamp:(nullable NSDate *)timestamp
-{
-    [self finishWithStatus:kSentrySpanStatusOk timestamp:timestamp];
-}
-
 - (void)finishWithStatus:(SentrySpanStatus)status
-{
-    [self finishWithStatus:status timestamp:[SentryCurrentDate date]];
-}
-
-- (void)finishWithStatus:(SentrySpanStatus)status timestamp:(nullable NSDate *)timestamp
 {
     self.context.status = status;
     if (self.timestamp == nil) {

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -41,7 +41,6 @@ SentryTracer ()
 @property (nonatomic, strong) SentrySpan *rootSpan;
 @property (nonatomic, strong) SentryHub *hub;
 @property (nonatomic) SentrySpanStatus finishStatus;
-@property (nonatomic, strong) NSDate *finishTimestamp;
 @property (nonatomic) BOOL isWaitingForChildren;
 @property (nonatomic) NSTimeInterval idleTimeout;
 @property (nonatomic, nullable, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
@@ -396,21 +395,10 @@ static NSLock *profilerLock;
     [self finishWithStatus:kSentrySpanStatusOk];
 }
 
-- (void)finishWithTimestamp:(nullable NSDate *)timestamp
-{
-    [self finishWithStatus:kSentrySpanStatusOk timestamp:timestamp];
-}
-
 - (void)finishWithStatus:(SentrySpanStatus)status
-{
-    [self finishWithStatus:status timestamp:nil];
-}
-
-- (void)finishWithStatus:(SentrySpanStatus)status timestamp:(nullable NSDate *)timestamp
 {
     self.isWaitingForChildren = YES;
     _finishStatus = status;
-    _finishTimestamp = timestamp;
 
     [self cancelIdleTimeout];
     [self canBeFinished];
@@ -453,7 +441,7 @@ static NSLock *profilerLock;
 
 - (void)finishInternal
 {
-    [_rootSpan finishWithStatus:_finishStatus timestamp:_finishTimestamp];
+    [_rootSpan finishWithStatus:_finishStatus];
 
     if (self.finishCallback) {
         self.finishCallback(self);

--- a/Tests/SentryTests/Protocol/SentryDebugMetaEquality.swift
+++ b/Tests/SentryTests/Protocol/SentryDebugMetaEquality.swift
@@ -5,8 +5,7 @@ extension DebugMeta {
         if  let other = object as? DebugMeta {
             return  uuid == other.uuid &&
                 type == other.type &&
-                name == other.name  &&
-                imageSize == other.imageSize &&
+                name == other.name && imageSize == other.imageSize &&
                 imageAddress == other.imageAddress &&
                 imageVmAddress == other.imageVmAddress
         } else {

--- a/Tests/SentryTests/Protocol/SentryThreadEquality.swift
+++ b/Tests/SentryTests/Protocol/SentryThreadEquality.swift
@@ -6,8 +6,7 @@ extension Sentry.Thread {
             return  threadId == other.threadId &&
                 name == other.name &&
                 stacktrace == other.stacktrace &&
-                crashed == other.crashed  &&
-                current == other.current
+                crashed == other.crashed && current == other.current
         } else {
             return false
         }

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -63,6 +63,28 @@ class SentrySpanTests: XCTestCase {
         XCTAssertEqual(lastEvent.startTimestamp, TestData.timestamp)
         XCTAssertEqual(lastEvent.type, SentryEnvelopeItemTypeTransaction)
     }
+    
+    func testFinish_Custom_Timestamp() {
+        let client = TestClient(options: fixture.options)!
+        let span = fixture.getSut(client: client)
+        
+        let finishDate = Date(timeIntervalSinceNow: 6)
+        
+        span.timestamp = finishDate
+        
+        span.finish()
+        
+        XCTAssertEqual(span.startTimestamp, TestData.timestamp)
+        XCTAssertEqual(span.timestamp, finishDate)
+        XCTAssertTrue(span.isFinished)
+        XCTAssertEqual(span.context.status, .ok)
+        
+        let lastEvent = client.captureEventWithScopeInvocations.invocations[0].event
+        XCTAssertEqual(lastEvent.transaction, fixture.someTransaction)
+        XCTAssertEqual(lastEvent.timestamp, finishDate)
+        XCTAssertEqual(lastEvent.startTimestamp, TestData.timestamp)
+        XCTAssertEqual(lastEvent.type, SentryEnvelopeItemTypeTransaction)
+    }
 
     func testFinishSpanWithDefaultTimestamp() {
         let span = SentrySpan(transaction: fixture.tracer, context: SpanContext(operation: fixture.someOperation, sampled: .undecided))

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -308,24 +308,4 @@ class SentrySpanTests: XCTestCase {
         group.wait()
         XCTAssertEqual(span.data!.count, outerLoop * innerLoop)
     }
-
-    func testFinishTimestampIsParameterNotCurrent() {
-        let client = TestClient(options: fixture.options)!
-        let span = fixture.getSut(client: client)
-
-        let startTimestamp = TestData.timestamp
-        // Set finish time to after the start time
-        let finishTimestamp = TestData.timestamp.addingTimeInterval(20)
-        // Set "current date" to even later than the finish time
-        fixture.currentDateProvider.setDate(date: TestData.timestamp.addingTimeInterval(40))
-
-        span.finish(timestamp: finishTimestamp)
-
-        XCTAssertEqual(span.startTimestamp?.timeIntervalSince1970, startTimestamp.timeIntervalSince1970)
-        XCTAssertEqual(span.timestamp?.timeIntervalSince1970, finishTimestamp.timeIntervalSince1970)
-        XCTAssertNotEqual(span.startTimestamp?.timeIntervalSince1970, span.timestamp?.timeIntervalSince1970)
-        XCTAssertNotEqual(span.timestamp?.timeIntervalSince1970, fixture.currentDateProvider.date().timeIntervalSince1970)
-        XCTAssertTrue(span.isFinished)
-        XCTAssertEqual(span.context.status, .ok)
-    }
 }

--- a/Tests/SentryTests/Transaction/TestSentrySpan.m
+++ b/Tests/SentryTests/Transaction/TestSentrySpan.m
@@ -39,14 +39,6 @@
 {
 }
 
-- (void)finishWithTimestamp:(NSDate *)timestamp
-{
-}
-
-- (void)finishWithStatus:(SentrySpanStatus)status timestamp:(NSDate *)timestamp
-{
-}
-
 - (void)removeDataForKey:(nonnull NSString *)key
 {
 }


### PR DESCRIPTION
Sentry added their own implementation that allowed setting a custom
timestamp for the end of a span in [sentry-cocoa/pull/1993][1]. However,
their implementation did not correctly support setting the `timestamp`
value on the top level `SentryTracer` span (aka: `rootSpan`) because
that passed through to the `rootSpan` and then the tracer only check if
the `rootSpan` had a timestamp set. If the `rootSpan` did have a
timestamp but the tracer itself had not been finished then the internal
finishing code would short circuit and never send to the server.

Sentry fixed upstream after reporting the issue. This PR includes that
along with deleting the code we added to pass along the `timestamp` to
various `finish` calls.

## Changes
- Remove our custom finish code
- Use upstream's ability to set the `timestamp` value

## Test Plan
- Update Arc to use local check out of Sentry (or point the Package to
  this commit)
- Build Arc and enable Sentry instrumentation
- Verify that results make it up to Sentry


[1]: https://github.com/getsentry/sentry-cocoa/pull/1993

