### PR TITLE
Add EXC_CRASH to Mach exception mask

### DIFF
--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -457,12 +457,11 @@ installExceptionHandler(void)
     int error;
 
     const task_t thisTask = mach_task_self();
-    // This is the default, which breaks widevine:
-    // `exception_mask_t mask = EXC_MASK_BAD_ACCESS | EXC_MASK_BAD_INSTRUCTION | EXC_MASK_ARITHMETIC | EXC_MASK_SOFTWARE | EXC_MASK_BREAKPOINT;`
-    // Following is used by chromium's crashpad, which works with widevine
-    // We're not seeing some crashed being picked up by the mach exception handler with this
-    // but they still end up in Sentry via the signal handler.
-    exception_mask_t mask = EXC_MASK_CRASH | EXC_MASK_BAD_ACCESS;
+    // This is the default, which does not include EXC_CRASH
+    // `exception_mask_t mask = EXC_MASK_BAD_ACCESS | EXC_MASK_BAD_INSTRUCTION | EXC_MASK_ARITHMETIC | EXC_MASK_SOFTWARE | EXC_MASK_BREAKPOINT;
+    // However, if one cannot rely on Posix signal handlers for capturing
+    // SIGABRT, the Mach exception mask above is missing EXC_MASK_CRASH:
+    exception_mask_t mask = EXC_MASK_CRASH | EXC_MASK_BAD_ACCESS | EXC_MASK_BAD_INSTRUCTION | EXC_MASK_ARITHMETIC | EXC_MASK_SOFTWARE | EXC_MASK_BREAKPOINT;
 
     SentryCrashLOG_DEBUG("Backing up original exception ports.");
     kr = task_get_exception_ports(thisTask, mask, g_previousExceptionPorts.masks,

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -458,10 +458,11 @@ installExceptionHandler(void)
 
     const task_t thisTask = mach_task_self();
     // This is the default, which does not include EXC_CRASH
-    // `exception_mask_t mask = EXC_MASK_BAD_ACCESS | EXC_MASK_BAD_INSTRUCTION | EXC_MASK_ARITHMETIC | EXC_MASK_SOFTWARE | EXC_MASK_BREAKPOINT;
-    // However, if one cannot rely on Posix signal handlers for capturing
-    // SIGABRT, the Mach exception mask above is missing EXC_MASK_CRASH:
-    exception_mask_t mask = EXC_MASK_CRASH | EXC_MASK_BAD_ACCESS | EXC_MASK_BAD_INSTRUCTION | EXC_MASK_ARITHMETIC | EXC_MASK_SOFTWARE | EXC_MASK_BREAKPOINT;
+    // `exception_mask_t mask = EXC_MASK_BAD_ACCESS | EXC_MASK_BAD_INSTRUCTION | EXC_MASK_ARITHMETIC
+    // | EXC_MASK_SOFTWARE | EXC_MASK_BREAKPOINT; However, if one cannot rely on Posix signal
+    // handlers for capturing SIGABRT, the Mach exception mask above is missing EXC_MASK_CRASH:
+    exception_mask_t mask = EXC_MASK_CRASH | EXC_MASK_BAD_ACCESS | EXC_MASK_BAD_INSTRUCTION
+        | EXC_MASK_ARITHMETIC | EXC_MASK_SOFTWARE | EXC_MASK_BREAKPOINT;
 
     SentryCrashLOG_DEBUG("Backing up original exception ports.");
     kr = task_get_exception_ports(thisTask, mask, g_previousExceptionPorts.masks,

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
@@ -288,8 +288,8 @@ typedef struct __CFRuntimeBase {
 #    define __CF_BIG_ENDIAN__ 0
 #endif
 
-#define CF_INFO_BITS (!!(__CF_BIG_ENDIAN__)*3)
-#define CF_RC_BITS (!!(__CF_LITTLE_ENDIAN__)*3)
+#define CF_INFO_BITS (!!(__CF_BIG_ENDIAN__) * 3)
+#define CF_RC_BITS (!!(__CF_LITTLE_ENDIAN__) * 3)
 
 /* Bit manipulation macros */
 /* Bits are numbered from 31 on left to 0 on right */
@@ -299,7 +299,7 @@ typedef struct __CFRuntimeBase {
 /* In the following, N1 and N2 specify an inclusive range N2..N1 with N1 >= N2
  */
 #define __CFBitfieldMask(N1, N2) ((((UInt32)~0UL) << (31UL - (N1) + (N2))) >> (31UL - N1))
-#define __CFBitfieldGetValue(V, N1, N2) (((V)&__CFBitfieldMask(N1, N2)) >> (N2))
+#define __CFBitfieldGetValue(V, N1, N2) (((V) & __CFBitfieldMask(N1, N2)) >> (N2))
 
 // ======================================================================
 #pragma mark - CF-1153.18/CFString.c -

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -801,10 +801,8 @@
 - (void)testChanging_enableTracing_afterSetting_tracesSampler
 {
     SentryOptions *options = [[SentryOptions alloc] init];
-    options.tracesSampler = ^NSNumber *(SentrySamplingContext *__unused samplingContext)
-    {
-        return @0.1;
-    };
+    options.tracesSampler
+        = ^NSNumber *(SentrySamplingContext *__unused samplingContext) { return @0.1; };
     options.enableTracing = NO;
     XCTAssertNil(options.tracesSampleRate);
     options.enableTracing = FALSE;
@@ -1161,10 +1159,8 @@
 
 - (void)testInitialScope
 {
-    SentryScope * (^initialScope)(SentryScope *) = ^SentryScope *(SentryScope *scope)
-    {
-        return scope;
-    };
+    SentryScope * (^initialScope)(SentryScope *)
+        = ^SentryScope *(SentryScope *scope) { return scope; };
     SentryOptions *options = [self getValidOptions:@{ @"initialScope" : initialScope }];
     XCTAssertIdentical(initialScope, options.initialScope);
 }


### PR DESCRIPTION
## :scroll: Description

Reset Mach exception handlers to upstream and add EXC_CRASH

## :bulb: Motivation and Context

For a couple of years, this branch was patched to handle only a subset of
Mach exception masks. This PR adds back all the missing exceptions, and in
addition, it adds EXC_CRASH which is not handled upstream.

This was necessary because a library was resetting the Posix signal handlers, and
thus nothing besides the Mach exceptions were being handled anymore.

#incident-2023-09-15-potentially-missing-crashes-in-sentry-sev3

## :green_heart: How did you test it?
Added tests to the client code that validates that specific crashes generate
sentry JSON reports on disk.
